### PR TITLE
Fix race condition in SQS Extended Client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@crimson-education/client-sqs-extended",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@crimson-education/client-sqs-extended",
-      "version": "1.0.2",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "uuid": "^8.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crimson-education/client-sqs-extended",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Extended SQS client library for managing large AWS SQS message payloads using S3",
   "author": "Ian Wang, DVLA, Crimson Education",
   "license": "MIT",


### PR DESCRIPTION
- Simplify client implementation by removing transforms + replacing request wrappers with ordered operations
- Fixed race condition where S3 content was stored after the sqs message was sent, and the sqs lambda listener was trying to fetch a file that hadn't been uploaded yet (Only appeared in production, as prod lambda was hot)